### PR TITLE
chore: Simplify type annotations for SQLAlchemy v2

### DIFF
--- a/sqlcompyre/analysis/dialects/_base.py
+++ b/sqlcompyre/analysis/dialects/_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from datetime import datetime

--- a/sqlcompyre/analysis/dialects/_base.py
+++ b/sqlcompyre/analysis/dialects/_base.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Protocol
 
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 
 class DialectProtocol(Protocol):
@@ -40,7 +39,7 @@ class DialectProtocol(Protocol):
     views_support_notnull_columns: bool
 
     def get_table_creation_timestamps(
-        self, engine: Engine, tables: list[sa.Table]
+        self, engine: sa.Engine, tables: list[sa.Table]
     ) -> list[datetime]:
         """Obtain the creation timestamps from a list of tables.
 

--- a/sqlcompyre/analysis/dialects/mssql.py
+++ b/sqlcompyre/analysis/dialects/mssql.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.mssql import dialect as SqlAlchemyMssqlDialect  # noqa: N812
-from sqlalchemy.engine import Engine
 
 from ._base import DialectProtocol
 
@@ -22,7 +21,7 @@ class MssqlDialect(SqlAlchemyMssqlDialect, DialectProtocol):  # type: ignore
     views_support_notnull_columns: bool = True
 
     def get_table_creation_timestamps(
-        self, engine: Engine, tables: list[sa.Table]
+        self, engine: sa.Engine, tables: list[sa.Table]
     ) -> list[datetime]:
         # Potentially, we need to get the database from the tables
         db: str | None = None

--- a/sqlcompyre/analysis/dialects/mssql.py
+++ b/sqlcompyre/analysis/dialects/mssql.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from datetime import datetime

--- a/sqlcompyre/analysis/query_inspection.py
+++ b/sqlcompyre/analysis/query_inspection.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/sqlcompyre/analysis/query_inspection.py
+++ b/sqlcompyre/analysis/query_inspection.py
@@ -5,7 +5,6 @@
 from functools import cached_property, lru_cache
 
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 
 class QueryInspection:
@@ -16,7 +15,7 @@ class QueryInspection:
         or :meth:`~sqlcompyre.api.inspect_table` functions instead.
     """
 
-    def __init__(self, engine: Engine, selectable: sa.Select):
+    def __init__(self, engine: sa.Engine, selectable: sa.Select):
         """
         Args:
             engine: The engine to use for connecting to the database.

--- a/sqlcompyre/analysis/schema_comparison.py
+++ b/sqlcompyre/analysis/schema_comparison.py
@@ -6,8 +6,7 @@ import re
 from functools import cached_property
 from typing import Literal, cast
 
-from sqlalchemy import schema
-from sqlalchemy.engine import Engine
+import sqlalchemy as sa
 from tqdm.auto import tqdm
 
 from sqlcompyre.report import Report
@@ -27,11 +26,11 @@ class SchemaComparison:
 
     def __init__(
         self,
-        engine: Engine,
+        engine: sa.Engine,
         left_schema: str,
         right_schema: str,
-        left_tables: dict[str, schema.Table],
-        right_tables: dict[str, schema.Table],
+        left_tables: dict[str, sa.Table],
+        right_tables: dict[str, sa.Table],
         float_precision: float,
         collation: str | None,
         ignore_casing: bool,

--- a/sqlcompyre/analysis/schema_comparison.py
+++ b/sqlcompyre/analysis/schema_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging

--- a/sqlcompyre/api.py
+++ b/sqlcompyre/api.py
@@ -4,7 +4,6 @@
 import sys
 
 import sqlalchemy as sa
-from sqlalchemy import schema
 
 from .analysis import QueryInspection, SchemaComparison, TableComparison
 
@@ -248,7 +247,7 @@ def _get_tables_from_schema(
     schema: str,
     is_database: bool,
     include_views: bool,
-) -> list[schema.Table]:
+) -> list[sa.Table]:
     if is_database:
         engine = sa.create_engine(engine.url.set(database=schema))
         schemas = sa.inspect(engine).get_schema_names()

--- a/sqlcompyre/results/column_matches.py
+++ b/sqlcompyre/results/column_matches.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import dataclass

--- a/sqlcompyre/results/column_matches.py
+++ b/sqlcompyre/results/column_matches.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from sqlalchemy.sql import selectable
+import sqlalchemy as sa
 
 
 @dataclass
@@ -15,4 +15,4 @@ class ColumnMatches:
     fraction_same: dict[str, float]
     #: Dictionary mapping the name of the left-table column to a query of all joined rows for
     #: which the column does not have the same value in both tables.
-    mismatch_selects: dict[str, selectable.Select]
+    mismatch_selects: dict[str, sa.Select]

--- a/sqlcompyre/results/row_matches.py
+++ b/sqlcompyre/results/row_matches.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import dataclass

--- a/sqlcompyre/results/row_matches.py
+++ b/sqlcompyre/results/row_matches.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 
-from sqlalchemy.sql import selectable
+import sqlalchemy as sa
 
 
 @dataclass
@@ -21,12 +21,12 @@ class RowMatches:
     #: Number of rows that could be joined
     n_joined_total: int
     #: Query for obtaining all rows from the left table that could not be joined.
-    unjoined_left: selectable.Select
+    unjoined_left: sa.Select
     #: Query for obtaining all rows from the right table that could not be joined.
-    unjoined_right: selectable.Select
+    unjoined_right: sa.Select
     #: Query for obtaining all rows that could be joined and were identical across the two tables.
-    joined_equal: selectable.Select
+    joined_equal: sa.Select
     #: Query for obtaining all rows that could be joined but were not identical.
-    joined_unequal: selectable.Select
+    joined_unequal: sa.Select
     #: Query for obtaining all rows that were joined, regardless of equality.
-    joined_total: selectable.Select
+    joined_total: sa.Select

--- a/tests/_shared/dialects.py
+++ b/tests/_shared/dialects.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/tests/_shared/dialects.py
+++ b/tests/_shared/dialects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 
-from sqlalchemy.engine import url
+import sqlalchemy as sa
 
 from sqlcompyre.analysis.dialects import DialectProtocol
 
@@ -17,15 +17,13 @@ def dialect_from_env() -> DialectProtocol:
     connection string. **Use this function with care!** Typically, it should only be
     used for ``pytest.mark.skipif`` statements.
     """
-    conn = url.make_url(os.environ["DB_CONNECTION_STRING"])
+    conn = sa.make_url(os.environ["DB_CONNECTION_STRING"])
     return dialect_from_connection_url(conn)
 
 
-def dialect_from_connection_url(conn_url: url.URL) -> DialectProtocol:
+def dialect_from_connection_url(conn_url: sa.URL) -> DialectProtocol:
     """Get dialect metadata from the connection URL."""
-    from sqlalchemy import create_engine
-
-    dialect = create_engine(conn_url).dialect
+    dialect = sa.create_engine(conn_url).dialect
     match dialect.name:
         case "mssql":
             from sqlcompyre.analysis.dialects import MssqlDialect

--- a/tests/_shared/schema.py
+++ b/tests/_shared/schema.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sqlalchemy as sa
-from sqlalchemy.engine import reflection, url
 from sqlalchemy.schema import CreateSchema, DropSchema
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
@@ -12,7 +11,7 @@ from .dialects import dialect_from_connection_url
 class SchemaFactory:
     """Simple utility class to create schemas for testing."""
 
-    def __init__(self, connection_url: url.URL):
+    def __init__(self, connection_url: sa.URL):
         """
         Args:
             connection_url: The connection string to connect to the database.
@@ -42,7 +41,7 @@ class SchemaFactory:
 
         # For all other databases, we simply create a schema
         engine = sa.create_engine(self.connection_url)
-        inspector: reflection.Inspector = sa.inspect(engine)
+        inspector = sa.inspect(engine)
         with engine.connect() as conn:
             if name in inspector.get_schema_names():
                 conn.execute(DropSchema(name, cascade=True))

--- a/tests/_shared/schema.py
+++ b/tests/_shared/schema.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sqlalchemy as sa

--- a/tests/_shared/tables.py
+++ b/tests/_shared/tables.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any

--- a/tests/_shared/tables.py
+++ b/tests/_shared/tables.py
@@ -4,17 +4,15 @@
 from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy import MetaData, schema
-from sqlalchemy.engine import Engine
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.schema import DDLElement, DropTable
-from sqlalchemy.sql import compiler, selectable
+from sqlalchemy.schema import DropTable
+from sqlalchemy.sql import compiler
 
 
 class TableFactory:
     """Simple utility class to create tables for testing."""
 
-    def __init__(self, engine: Engine, schema: str | None):
+    def __init__(self, engine: sa.Engine, schema: str | None):
         """
         Args:
             engine: The engine to interact with the database.
@@ -23,12 +21,12 @@ class TableFactory:
         """
         self.engine = engine
         self.schema = schema
-        self.metadata = MetaData()
+        self.metadata = sa.MetaData()
 
     def create(
         self,
         name: str,
-        columns: list[schema.Column],
+        columns: list[sa.Column],
         data: list[dict[str, Any]],
     ) -> sa.Table:
         """Creates a new table in the database with the given metadata and values."""
@@ -41,7 +39,7 @@ class TableFactory:
                 trans.execute(table.insert().values(), data)
             return table
 
-    def create_view(self, name: str, query: selectable.Select) -> sa.Table:
+    def create_view(self, name: str, query: sa.Select) -> sa.Table:
         """Creates a new view in the database using the given query."""
         schema: str | None
         if self.schema is not None and len(self.schema.split(".")) > 1:
@@ -68,7 +66,7 @@ class TableFactory:
 # -------------------------------------------------------------------------------------------------
 
 
-class _DropView(DDLElement):
+class _DropView(sa.DDLElement):
     def __init__(self, name: str):
         self.name = name
 
@@ -85,8 +83,8 @@ def visit_drop_view(  # noqa
 # -------------------------------------------------------------------------------------------------
 
 
-class _CreateView(DDLElement):
-    def __init__(self, name: str, select: selectable.Select):
+class _CreateView(sa.DDLElement):
+    def __init__(self, name: str, select: sa.Select):
         self.name = name
         self.select = select
 

--- a/tests/analysis/dialects/test_mssql.py
+++ b/tests/analysis/dialects/test_mssql.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import time

--- a/tests/analysis/dialects/test_mssql.py
+++ b/tests/analysis/dialects/test_mssql.py
@@ -7,8 +7,6 @@ from datetime import datetime
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 from sqlcompyre.analysis.dialects import MssqlDialect
 from tests._shared import SchemaFactory, TableFactory, dialect_from_env
@@ -19,8 +17,8 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def table_columns() -> list[Column]:
-    return [Column("id", Integer(), primary_key=True)]
+def table_columns() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer(), primary_key=True)]
 
 
 @pytest.fixture(scope="session")
@@ -30,7 +28,7 @@ def creation_timestamp() -> datetime:
 
 @pytest.fixture()  # do not use a scope here as this fixture is modified in tests
 def schema_and_tables_and_views(
-    engine: Engine,
+    engine: sa.Engine,
     schema_factory: SchemaFactory,
     creation_timestamp: datetime,  # keep here to initialize the fixture
 ) -> tuple[str, sa.Table, sa.Table, sa.Table]:
@@ -48,7 +46,7 @@ def schema_and_tables_and_views(
 
 
 def test_get_table_creation_timestamps(
-    engine: Engine,
+    engine: sa.Engine,
     schema_and_tables_and_views: tuple[str, sa.Table, sa.Table, sa.Table],
     creation_timestamp: datetime,
 ):
@@ -65,7 +63,7 @@ def test_get_table_creation_timestamps(
 
 
 def test_get_table_creation_timestamps_different_database(
-    engine: Engine,
+    engine: sa.Engine,
     schema_and_tables_and_views: tuple[str, sa.Table, sa.Table, sa.Table],
 ):
     _, table1, table2, _ = schema_and_tables_and_views
@@ -76,7 +74,7 @@ def test_get_table_creation_timestamps_different_database(
 
 
 def test_get_table_creation_timestamps_different_multipart(
-    engine: Engine,
+    engine: sa.Engine,
     schema_and_tables_and_views: tuple[str, sa.Table, sa.Table, sa.Table],
 ):
     _, table1, table2, _ = schema_and_tables_and_views

--- a/tests/analysis/query_inspection/conftest.py
+++ b/tests/analysis/query_inspection/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/tests/analysis/query_inspection/conftest.py
+++ b/tests/analysis/query_inspection/conftest.py
@@ -4,7 +4,6 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer, String
 
 from tests._shared import TableFactory
 
@@ -20,11 +19,11 @@ CHARACTER_DATA = [
 ]
 
 
-def columns() -> list[Column]:
+def columns() -> list[sa.Column]:
     return [
-        Column("first_name", String(length=20)),
-        Column("last_name", String(length=20)),
-        Column("age", Integer()),
+        sa.Column("first_name", sa.String(length=20)),
+        sa.Column("last_name", sa.String(length=20)),
+        sa.Column("age", sa.Integer()),
     ]
 
 

--- a/tests/analysis/query_inspection/test_row_counts.py
+++ b/tests/analysis/query_inspection/test_row_counts.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/tests/analysis/query_inspection/test_row_counts.py
+++ b/tests/analysis/query_inspection/test_row_counts.py
@@ -4,22 +4,21 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
-def test_row_count(engine: Engine, table_characters: sa.Table):
+def test_row_count(engine: sa.Engine, table_characters: sa.Table):
     inspection = sc.inspect_table(engine, table_characters)
     assert inspection.row_count == 8
 
 
-def test_row_count_table_string(engine: Engine, table_characters: sa.Table):
+def test_row_count_table_string(engine: sa.Engine, table_characters: sa.Table):
     inspection = sc.inspect_table(engine, str(table_characters))
     assert inspection.row_count == 8
 
 
-def test_row_count_query(engine: Engine, table_characters: sa.Table):
+def test_row_count_query(engine: sa.Engine, table_characters: sa.Table):
     inspection = sc.inspect(
         engine,
         sa.select(table_characters).where(
@@ -29,7 +28,7 @@ def test_row_count_query(engine: Engine, table_characters: sa.Table):
     assert inspection.row_count == 6
 
 
-def test_row_count_raw_query(engine: Engine, table_characters: sa.Table):
+def test_row_count_raw_query(engine: sa.Engine, table_characters: sa.Table):
     inspection = sc.inspect(
         engine,
         f"""
@@ -50,7 +49,7 @@ def test_row_count_raw_query(engine: Engine, table_characters: sa.Table):
     [([], 7), (["last_name"], 3), (["last_name", "age"], 5)],
 )
 def test_distinct_row_count(
-    engine: Engine, table_characters: sa.Table, columns: list[str], expected: int
+    engine: sa.Engine, table_characters: sa.Table, columns: list[str], expected: int
 ):
     inspection = sc.inspect_table(engine, table_characters)
     assert inspection.distinct_row_count(*columns) == expected

--- a/tests/analysis/schema_comparison/conftest.py
+++ b/tests/analysis/schema_comparison/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import time

--- a/tests/analysis/schema_comparison/conftest.py
+++ b/tests/analysis/schema_comparison/conftest.py
@@ -5,22 +5,23 @@ import time
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 from tests._shared import SchemaFactory, TableFactory
 
 
-def table_columns() -> list[Column]:
-    return [Column("id", Integer(), primary_key=True), Column("value", Integer())]
+def table_columns() -> list[sa.Column]:
+    return [
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("value", sa.Integer()),
+    ]
 
 
-def table_columns_no_pk() -> list[Column]:
-    return [Column("id", Integer())]
+def table_columns_no_pk() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer())]
 
 
 @pytest.fixture(scope="session")
-def schema_1(engine: Engine, schema_factory: SchemaFactory) -> str:
+def schema_1(engine: sa.Engine, schema_factory: SchemaFactory) -> str:
     schema = schema_factory.create("compyre_full_1")
     factory = TableFactory(engine, schema)
     factory.create("table4", table_columns(), [])
@@ -36,7 +37,7 @@ def schema_1(engine: Engine, schema_factory: SchemaFactory) -> str:
 
 
 @pytest.fixture(scope="session")
-def schema_2(engine: Engine, schema_factory: SchemaFactory) -> str:
+def schema_2(engine: sa.Engine, schema_factory: SchemaFactory) -> str:
     schema = schema_factory.create("compyre_full_2")
     factory = TableFactory(engine, schema)
     table1 = factory.create("table1", table_columns(), [dict(id=1, value=4)])
@@ -49,7 +50,7 @@ def schema_2(engine: Engine, schema_factory: SchemaFactory) -> str:
 
 
 @pytest.fixture(scope="session")
-def schema_duplicate_table(engine: Engine, schema_factory: SchemaFactory) -> str:
+def schema_duplicate_table(engine: sa.Engine, schema_factory: SchemaFactory) -> str:
     schema = schema_factory.create("compyre_full_3")
     factory = TableFactory(engine, schema)
     factory.create("table1", table_columns_no_pk(), [dict(id=1), dict(id=1)])

--- a/tests/analysis/schema_comparison/test_comparison.py
+++ b/tests/analysis/schema_comparison/test_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest

--- a/tests/analysis/schema_comparison/test_comparison.py
+++ b/tests/analysis/schema_comparison/test_comparison.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
-from sqlalchemy.engine import Engine
+import sqlalchemy as sa
 
 import sqlcompyre as sc
 from tests._shared import dialect_from_env
@@ -13,13 +13,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_table_counts(engine: Engine, schema_1: str, schema_2: str):
+def test_table_counts(engine: sa.Engine, schema_1: str, schema_2: str):
     comparison = sc.compare_schemas(engine, schema_1, schema_2)
     assert comparison.table_counts.left == 4
     assert comparison.table_counts.right == 3
 
 
-def test_table_names(engine: Engine, schema_1: str, schema_2: str):
+def test_table_names(engine: sa.Engine, schema_1: str, schema_2: str):
     comparison = sc.compare_schemas(engine, schema_1, schema_2)
     assert not comparison.table_names.equal
     assert comparison.table_names.in_common == ["table1", "table4"]
@@ -27,13 +27,13 @@ def test_table_names(engine: Engine, schema_1: str, schema_2: str):
     assert comparison.table_names.missing_left == ["table5"]
 
 
-def test_table_counts_with_views(engine: Engine, schema_1: str, schema_2: str):
+def test_table_counts_with_views(engine: sa.Engine, schema_1: str, schema_2: str):
     comparison = sc.compare_schemas(engine, schema_1, schema_2, include_views=True)
     assert comparison.table_counts.left == 6
     assert comparison.table_counts.right == 4
 
 
-def test_table_names_with_views(engine: Engine, schema_1: str, schema_2: str):
+def test_table_names_with_views(engine: sa.Engine, schema_1: str, schema_2: str):
     comparison = sc.compare_schemas(engine, schema_1, schema_2, include_views=True)
     assert not comparison.table_names.equal
     assert comparison.table_names.in_common == ["table1", "table4", "view1"]
@@ -41,6 +41,6 @@ def test_table_names_with_views(engine: Engine, schema_1: str, schema_2: str):
     assert comparison.table_names.missing_left == ["table5"]
 
 
-def test_report(engine: Engine, schema_1: str, schema_2: str):
+def test_report(engine: sa.Engine, schema_1: str, schema_2: str):
     report = sc.compare_schemas(engine, schema_1, schema_2).summary_report()
     assert len(report.sections) == 2

--- a/tests/analysis/schema_comparison/test_reports.py
+++ b/tests/analysis/schema_comparison/test_reports.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Literal

--- a/tests/analysis/schema_comparison/test_reports.py
+++ b/tests/analysis/schema_comparison/test_reports.py
@@ -4,7 +4,7 @@
 from typing import Literal
 
 import pytest
-from sqlalchemy.engine import Engine
+import sqlalchemy as sa
 
 import sqlcompyre as sc
 from tests._shared import dialect_from_env
@@ -15,12 +15,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_report(engine: Engine, schema_1: str, schema_2: str):
+def test_report(engine: sa.Engine, schema_1: str, schema_2: str):
     report = sc.compare_schemas(engine, schema_1, schema_2).summary_report()
     assert len(report.sections) == 2
 
 
-def test_table_reports(engine: Engine, schema_1: str, schema_2: str):
+def test_table_reports(engine: sa.Engine, schema_1: str, schema_2: str):
     reports = sc.compare_schemas(engine, schema_1, schema_2).table_reports()
     assert set(reports.keys()) == {"table1", "table4"}
 
@@ -30,7 +30,7 @@ def test_table_reports(engine: Engine, schema_1: str, schema_2: str):
     [("name", ["table1", "table4"]), ("creation_timestamp", ["table4", "table1"])],
 )
 def test_table_reports_sort_by(
-    engine: Engine,
+    engine: sa.Engine,
     schema_1: str,
     schema_2: str,
     sort_by: Literal["name", "creation_timestamp"],
@@ -42,35 +42,37 @@ def test_table_reports_sort_by(
     assert [key for key in reports] == tables
 
 
-def test_table_reports_skip_equal(engine: Engine, schema_1: str, schema_2: str):
+def test_table_reports_skip_equal(engine: sa.Engine, schema_1: str, schema_2: str):
     reports = sc.compare_schemas(engine, schema_1, schema_2).table_reports(
         skip_equal=True
     )
     assert len(reports) == 1
 
 
-def test_table_reports_no_join_columns(engine: Engine, schema_duplicate_table: str):
+def test_table_reports_no_join_columns(engine: sa.Engine, schema_duplicate_table: str):
     reports = sc.compare_schemas(
         engine, schema_duplicate_table, schema_duplicate_table
     ).table_reports(skip_equal=True)
     assert len(reports) == 0
 
 
-def test_table_reports_ignore_full(engine: Engine, schema_1: str, schema_2: str):
+def test_table_reports_ignore_full(engine: sa.Engine, schema_1: str, schema_2: str):
     reports = sc.compare_schemas(engine, schema_1, schema_2).table_reports(
         ignore_tables=["table4"], skip_equal=True
     )
     assert len(reports) == 1
 
 
-def test_table_reports_ignore_full_regex(engine: Engine, schema_1: str, schema_2: str):
+def test_table_reports_ignore_full_regex(
+    engine: sa.Engine, schema_1: str, schema_2: str
+):
     reports = sc.compare_schemas(engine, schema_1, schema_2).table_reports(
         ignore_tables=[r"table.*"], skip_equal=True
     )
     assert len(reports) == 0
 
 
-def test_table_reports_ignore_column(engine: Engine, schema_1: str, schema_2: str):
+def test_table_reports_ignore_column(engine: sa.Engine, schema_1: str, schema_2: str):
     reports = sc.compare_schemas(engine, schema_1, schema_2).table_reports(
         ignore_table_columns={"table1": ["value"]}, skip_equal=True
     )

--- a/tests/analysis/schema_comparison/test_table_comparison.py
+++ b/tests/analysis/schema_comparison/test_table_comparison.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
-from sqlalchemy.engine import Engine
+import sqlalchemy as sa
 
 import sqlcompyre as sc
 from tests._shared import dialect_from_env
@@ -13,7 +13,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_table_comparison_case_sensitive(engine: Engine, schema_1: str, schema_2: str):
+def test_table_comparison_case_sensitive(
+    engine: sa.Engine, schema_1: str, schema_2: str
+):
     comparison = sc.compare_schemas(engine, schema_1, schema_2)
 
     with pytest.raises(ValueError):
@@ -24,7 +26,7 @@ def test_table_comparison_case_sensitive(engine: Engine, schema_1: str, schema_2
 
 
 def test_table_comparison_case_insensitive(
-    engine: Engine, schema_1: str, schema_2: str
+    engine: sa.Engine, schema_1: str, schema_2: str
 ):
     comparison = sc.compare_schemas(engine, schema_1, schema_2, ignore_casing=True)
 

--- a/tests/analysis/schema_comparison/test_table_comparison.py
+++ b/tests/analysis/schema_comparison/test_table_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest

--- a/tests/analysis/table_comparison/conftest.py
+++ b/tests/analysis/table_comparison/conftest.py
@@ -5,7 +5,6 @@ import copy
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Float, Integer, String
 
 from tests._shared import TableFactory
 
@@ -18,39 +17,39 @@ STUDENT_DATA = [
 ]
 
 
-def base_columns() -> list[Column]:
+def base_columns() -> list[sa.Column]:
     return [
-        Column("id", Integer(), primary_key=True),
-        Column("name", String(length=50)),
-        Column("age", Integer()),
-        Column("gpa", Float()),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=50)),
+        sa.Column("age", sa.Integer()),
+        sa.Column("gpa", sa.Float()),
     ]
 
 
-def alt_columns() -> list[Column]:
+def alt_columns() -> list[sa.Column]:
     return [
-        Column("id_v2", Integer(), primary_key=True),
-        Column("name_v2", String(length=50)),
-        Column("age_v2", Integer()),
-        Column("gpa_v2", Float()),
+        sa.Column("id_v2", sa.Integer(), primary_key=True),
+        sa.Column("name_v2", sa.String(length=50)),
+        sa.Column("age_v2", sa.Integer()),
+        sa.Column("gpa_v2", sa.Float()),
     ]
 
 
-def alt_columns_small() -> list[Column]:
+def alt_columns_small() -> list[sa.Column]:
     return [
-        Column("id", Integer(), primary_key=True),
-        Column("name", String(length=50)),
-        Column("age_v2", Integer()),
-        Column("gpa_v2", Float()),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=50)),
+        sa.Column("age_v2", sa.Integer()),
+        sa.Column("gpa_v2", sa.Float()),
     ]
 
 
-def cased_columns() -> list[Column]:
+def cased_columns() -> list[sa.Column]:
     return [
-        Column("Id", Integer(), primary_key=True),
-        Column("Name", String(length=50)),
-        Column("Age", Integer()),
-        Column("Gpa", Float()),
+        sa.Column("Id", sa.Integer(), primary_key=True),
+        sa.Column("Name", sa.String(length=50)),
+        sa.Column("Age", sa.Integer()),
+        sa.Column("Gpa", sa.Float()),
     ]
 
 

--- a/tests/analysis/table_comparison/conftest.py
+++ b/tests/analysis/table_comparison/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy

--- a/tests/analysis/table_comparison/test_by_column.py
+++ b/tests/analysis/table_comparison/test_by_column.py
@@ -9,8 +9,6 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -20,11 +18,11 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns() -> list[Column]:
+def table_columns() -> list[sa.Column]:
     return [
-        Column("id", Integer(), primary_key=True),
-        Column("value", Integer(), nullable=True),
-        Column("value_1", Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("value", sa.Integer(), nullable=True),
+        sa.Column("value_1", sa.Integer(), nullable=True),
     ]
 
 
@@ -52,7 +50,7 @@ def anonymous_table_rhs(table_factory: TableFactory) -> sa.Table:
 
 
 def test_column_matches_percentages_different(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -64,7 +62,7 @@ def test_column_matches_percentages_different(
 
 
 def test_column_matches_percentages_different_dbs(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -75,7 +73,7 @@ def test_column_matches_percentages_different_dbs(
     assert math.isclose(column_matches.fraction_same["age"], 2 / 3, rel_tol=1e-6)
 
 
-def test_column_matches_percentages_same(engine: Engine, table_students: sa.Table):
+def test_column_matches_percentages_same(engine: sa.Engine, table_students: sa.Table):
     column_matches = sc.compare_tables(
         engine, table_students, table_students
     ).column_matches
@@ -84,7 +82,7 @@ def test_column_matches_percentages_same(engine: Engine, table_students: sa.Tabl
 
 
 def test_column_matches_percentages_same_selects(
-    engine: Engine, table_students: sa.Table
+    engine: sa.Engine, table_students: sa.Table
 ):
     column_matches = sc.compare_tables(
         engine, table_students, table_students
@@ -97,7 +95,7 @@ def test_column_matches_percentages_same_selects(
 
 
 def test_column_matches_anonymous_table_column_naming(
-    engine: Engine, anonymous_table_lhs: sa.Table, anonymous_table_rhs: sa.Table
+    engine: sa.Engine, anonymous_table_lhs: sa.Table, anonymous_table_rhs: sa.Table
 ):
     column_matches = sc.compare_tables(
         engine, anonymous_table_lhs, anonymous_table_rhs

--- a/tests/analysis/table_comparison/test_by_column.py
+++ b/tests/analysis/table_comparison/test_by_column.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify basic behavior of the column-specific

--- a/tests/analysis/table_comparison/test_column_matching.py
+++ b/tests/analysis/table_comparison/test_column_matching.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify the column matching ability of table

--- a/tests/analysis/table_comparison/test_column_matching.py
+++ b/tests/analysis/table_comparison/test_column_matching.py
@@ -7,13 +7,12 @@ comparisons."""
 import pandas as pd
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
 def test_name_verification(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -32,7 +31,7 @@ def test_name_verification(
 
 
 def test_name_verification_right_arbitrary_casing(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -50,7 +49,7 @@ def test_name_verification_right_arbitrary_casing(
 
 
 def test_arbitrary_name_casing(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -78,7 +77,7 @@ def test_arbitrary_name_casing(
 
 
 def test_partly_renaming(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_partly_renamed: sa.Table,
 ):
@@ -110,7 +109,7 @@ def test_partly_renaming(
 
 
 def test_automatic_case_matching(
-    engine: Engine, table_students: sa.Table, table_students_cased: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_cased: sa.Table
 ):
     with pytest.raises(ValueError):
         # Fail when not ignoring casing
@@ -128,7 +127,7 @@ def test_automatic_case_matching(
 
 
 def test_row_matches_different_unmatched_cols(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -142,7 +141,7 @@ def test_row_matches_different_unmatched_cols(
 
 
 def test_row_matches_different_matched_cols(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -157,7 +156,7 @@ def test_row_matches_different_matched_cols(
 
 
 def test_column_matches_percentages_different_dbs_cols(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_renamed: sa.Table,
 ):
@@ -172,7 +171,7 @@ def test_column_matches_percentages_different_dbs_cols(
 
 
 def test_column_matches_percentages_selects(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_renamed: sa.Table,
 ):

--- a/tests/analysis/table_comparison/test_column_names.py
+++ b/tests/analysis/table_comparison/test_column_names.py
@@ -5,31 +5,30 @@
 matches."""
 
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
-def test_column_names_equal_same_names(engine: Engine, table_students: sa.Table):
+def test_column_names_equal_same_names(engine: sa.Engine, table_students: sa.Table):
     # Check that column names are matched in two identical tables
     comparison = sc.compare_tables(engine, table_students, table_students)
     assert comparison.column_names.equal
 
 
-def test_column_names_equal_missing_1(engine: Engine, table_students: sa.Table):
+def test_column_names_equal_missing_1(engine: sa.Engine, table_students: sa.Table):
     # Check that there are no missing columns in two identical tables
     comparison = sc.compare_tables(engine, table_students, table_students)
     assert not comparison.column_names.missing_left
 
 
-def test_column_names_equal_missing_2(engine: Engine, table_students: sa.Table):
+def test_column_names_equal_missing_2(engine: sa.Engine, table_students: sa.Table):
     # Check that there are no missing columns in two identical tables
     comparison = sc.compare_tables(engine, table_students, table_students)
     assert not comparison.column_names.missing_right
 
 
 def test_column_names_unequal_same_names(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_narrow: sa.Table,
 ):
@@ -39,7 +38,7 @@ def test_column_names_unequal_same_names(
 
 
 def test_column_names_unequal_missing_1(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_narrow: sa.Table,
 ):
@@ -49,7 +48,7 @@ def test_column_names_unequal_missing_1(
 
 
 def test_column_names_unequal_missing_2(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_narrow: sa.Table,
 ):

--- a/tests/analysis/table_comparison/test_column_names.py
+++ b/tests/analysis/table_comparison/test_column_names.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify basic behavior for determining column name

--- a/tests/analysis/table_comparison/test_comparison.py
+++ b/tests/analysis/table_comparison/test_comparison.py
@@ -7,7 +7,6 @@ import logging
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import dialect_from_env
@@ -18,7 +17,7 @@ from tests._shared import dialect_from_env
     reason="Database system does not support schemas.",
 )
 def test_comparison_different_schema(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_other_schema: sa.Table,
 ):
@@ -31,7 +30,7 @@ def test_comparison_different_schema(
     reason="Database system does not support schemas.",
 )
 def test_comparison_string_tables(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_other_schema: sa.Table,
 ):
@@ -42,7 +41,7 @@ def test_comparison_string_tables(
 
 
 def test_comparison_string_views(
-    caplog: pytest.LogCaptureFixture, engine: Engine, view_students: sa.Table
+    caplog: pytest.LogCaptureFixture, engine: sa.Engine, view_students: sa.Table
 ):
     # Views don't have primary keys. Without inferring them, the report should only have two
     # sections

--- a/tests/analysis/table_comparison/test_comparison.py
+++ b/tests/analysis/table_comparison/test_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains general that verify SQLCompyre's table comparison."""

--- a/tests/analysis/table_comparison/test_equal.py
+++ b/tests/analysis/table_comparison/test_equal.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import Any

--- a/tests/analysis/table_comparison/test_equal.py
+++ b/tests/analysis/table_comparison/test_equal.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -16,8 +14,8 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns() -> list[Column]:
-    return [Column("id", Integer())]
+def table_columns() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer())]
 
 
 @pytest.fixture(scope="module")
@@ -49,46 +47,46 @@ def table_with_duplicates_2(table_factory: TableFactory) -> sa.Table:
 # -------------------------------------------------------------------------------------------------
 
 
-def test_equal_ok(engine: Engine, table_students: sa.Table):
+def test_equal_ok(engine: sa.Engine, table_students: sa.Table):
     comparison = sc.compare_tables(engine, table_students, table_students)
     assert comparison.equal
 
 
 def test_equal_err_count(
-    engine: Engine, table_students: sa.Table, table_students_small: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_small: sa.Table
 ):
     comparison = sc.compare_tables(engine, table_students, table_students_small)
     assert not comparison.equal
 
 
 def test_equal_err_columns(
-    engine: Engine, table_students: sa.Table, table_students_narrow: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_narrow: sa.Table
 ):
     comparison = sc.compare_tables(engine, table_students, table_students_narrow)
     assert not comparison.equal
 
 
 def test_equal_err_joined_unequal(
-    engine: Engine, table_students: sa.Table, table_students_modified_3: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_modified_3: sa.Table
 ):
     comparison = sc.compare_tables(engine, table_students, table_students_modified_3)
     assert not comparison.equal
 
 
-def test_equal_ok_no_join_columns_null(engine: Engine, table_with_null_1: sa.Table):
+def test_equal_ok_no_join_columns_null(engine: sa.Engine, table_with_null_1: sa.Table):
     comparison = sc.compare_tables(engine, table_with_null_1, table_with_null_1)
     assert comparison.equal
 
 
 def test_equal_err_no_join_columns_null(
-    engine: Engine, table_with_null_1: sa.Table, table_with_null_2: sa.Table
+    engine: sa.Engine, table_with_null_1: sa.Table, table_with_null_2: sa.Table
 ):
     comparison = sc.compare_tables(engine, table_with_null_1, table_with_null_2)
     assert not comparison.equal
 
 
 def test_equal_ok_no_join_columns_duplicates(
-    engine: Engine, table_with_duplicates_1: sa.Table
+    engine: sa.Engine, table_with_duplicates_1: sa.Table
 ):
     comparison = sc.compare_tables(
         engine, table_with_duplicates_1, table_with_duplicates_1
@@ -97,7 +95,9 @@ def test_equal_ok_no_join_columns_duplicates(
 
 
 def test_equal_err_no_join_columns_duplicates(
-    engine: Engine, table_with_duplicates_1: sa.Table, table_with_duplicates_2: sa.Table
+    engine: sa.Engine,
+    table_with_duplicates_1: sa.Table,
+    table_with_duplicates_2: sa.Table,
 ):
     comparison = sc.compare_tables(
         engine, table_with_duplicates_1, table_with_duplicates_2

--- a/tests/analysis/table_comparison/test_ignore_columns.py
+++ b/tests/analysis/table_comparison/test_ignore_columns.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
 def test_ignore_columns(
-    engine: Engine, table_students_small: sa.Table, table_students_modified_1: sa.Table
+    engine: sa.Engine,
+    table_students_small: sa.Table,
+    table_students_modified_1: sa.Table,
 ):
     comparison_all = sc.compare_tables(
         engine, table_students_small, table_students_modified_1

--- a/tests/analysis/table_comparison/test_ignore_columns.py
+++ b/tests/analysis/table_comparison/test_ignore_columns.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sqlalchemy as sa

--- a/tests/analysis/table_comparison/test_no_primary_key.py
+++ b/tests/analysis/table_comparison/test_no_primary_key.py
@@ -8,8 +8,6 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -19,19 +17,19 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns() -> list[Column]:
-    return [Column("id", Integer(), nullable=False)]
+def table_columns() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer(), nullable=False)]
 
 
-def only_nullable_columns() -> list[Column]:
-    return [Column("id", Integer())]
+def only_nullable_columns() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer())]
 
 
-def nullable_table_columns() -> list[Column]:
+def nullable_table_columns() -> list[sa.Column]:
     return [
-        Column("id", Integer(), nullable=False),
-        Column("other_with_null", Integer()),
-        Column("other_without_null", Integer()),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("other_with_null", sa.Integer()),
+        sa.Column("other_without_null", sa.Integer()),
     ]
 
 
@@ -82,7 +80,7 @@ def table_only_null(table_factory: TableFactory) -> sa.Table:
 # -------------------------------------------------------------------------------------------------
 
 
-def test_no_pk_row_matches(engine: Engine, table_lhs: sa.Table, table_rhs: sa.Table):
+def test_no_pk_row_matches(engine: sa.Engine, table_lhs: sa.Table, table_rhs: sa.Table):
     # Do not fail immediately if not inferring primary keys...
     comparison = sc.compare_tables(engine, table_lhs, table_rhs)
     assert comparison.row_counts.equal
@@ -101,7 +99,7 @@ def test_no_pk_row_matches(engine: Engine, table_lhs: sa.Table, table_rhs: sa.Ta
 
 
 def test_no_pk_row_matches_duplicates(
-    engine: Engine, table_lhs: sa.Table, table_rhs_duplicate: sa.Table
+    engine: sa.Engine, table_lhs: sa.Table, table_rhs_duplicate: sa.Table
 ):
     with pytest.raises(ValueError, match="would cause duplicates"):
         sc.compare_tables(
@@ -109,7 +107,7 @@ def test_no_pk_row_matches_duplicates(
         ).row_matches
 
 
-def test_no_pk_row_matches_nulls(engine: Engine, table_only_null: sa.Table):
+def test_no_pk_row_matches_nulls(engine: sa.Engine, table_only_null: sa.Table):
     with pytest.raises(ValueError, match="no non-null columns"):
         sc.compare_tables(
             engine, table_only_null, table_only_null, infer_primary_keys=True
@@ -117,7 +115,7 @@ def test_no_pk_row_matches_nulls(engine: Engine, table_only_null: sa.Table):
 
 
 def test_no_pk_row_matches_nullable_columns(
-    engine: Engine, table_lhs_nullable: sa.Table, table_rhs_nullable: sa.Table
+    engine: sa.Engine, table_lhs_nullable: sa.Table, table_rhs_nullable: sa.Table
 ):
     comparison = sc.compare_tables(
         engine, table_lhs_nullable, table_rhs_nullable, infer_primary_keys=True

--- a/tests/analysis/table_comparison/test_no_primary_key.py
+++ b/tests/analysis/table_comparison/test_no_primary_key.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify SQLCompyre's behavior when tables contain no

--- a/tests/analysis/table_comparison/test_null_values.py
+++ b/tests/analysis/table_comparison/test_null_values.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify SQLCompyre's behavior for NULL values."""

--- a/tests/analysis/table_comparison/test_null_values.py
+++ b/tests/analysis/table_comparison/test_null_values.py
@@ -8,8 +8,6 @@ from typing import Any
 import pandas as pd
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -19,10 +17,10 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns() -> list[Column]:
+def table_columns() -> list[sa.Column]:
     return [
-        Column("id", Integer(), primary_key=True),
-        Column("value", Integer(), nullable=True),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("value", sa.Integer(), nullable=True),
     ]
 
 
@@ -53,14 +51,16 @@ def table_rhs(table_factory: TableFactory) -> sa.Table:
 # -------------------------------------------------------------------------------------------------
 
 
-def test_null_equal(engine: Engine, table_lhs: sa.Table, table_rhs: sa.Table):
+def test_null_equal(engine: sa.Engine, table_lhs: sa.Table, table_rhs: sa.Table):
     row_matches = sc.compare_tables(engine, table_lhs, table_rhs).row_matches
     assert row_matches.n_joined_total == 4
     assert row_matches.n_joined_equal == 2
     assert row_matches.n_joined_unequal == 2
 
 
-def test_null_column_matches(engine: Engine, table_lhs: sa.Table, table_rhs: sa.Table):
+def test_null_column_matches(
+    engine: sa.Engine, table_lhs: sa.Table, table_rhs: sa.Table
+):
     column_matches = sc.compare_tables(engine, table_lhs, table_rhs).column_matches
     assert column_matches.fraction_same["value"] == 0.5
 
@@ -69,7 +69,7 @@ def test_null_column_matches(engine: Engine, table_lhs: sa.Table, table_rhs: sa.
 
 
 def test_null_top_changes(
-    engine: Engine,
+    engine: sa.Engine,
     table_lhs: sa.Table,
     table_rhs: sa.Table,
 ):

--- a/tests/analysis/table_comparison/test_only_primary_key.py
+++ b/tests/analysis/table_comparison/test_only_primary_key.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify SQLCompyre's behavior when tables contain only

--- a/tests/analysis/table_comparison/test_only_primary_key.py
+++ b/tests/analysis/table_comparison/test_only_primary_key.py
@@ -8,8 +8,6 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -19,8 +17,8 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns() -> list[Column]:
-    return [Column("id", Integer(), primary_key=True)]
+def table_columns() -> list[sa.Column]:
+    return [sa.Column("id", sa.Integer(), primary_key=True)]
 
 
 @pytest.fixture(scope="module")
@@ -40,7 +38,9 @@ def table_rhs(table_factory: TableFactory) -> sa.Table:
 # -------------------------------------------------------------------------------------------------
 
 
-def test_only_pk_row_matches(engine: Engine, table_lhs: sa.Table, table_rhs: sa.Table):
+def test_only_pk_row_matches(
+    engine: sa.Engine, table_lhs: sa.Table, table_rhs: sa.Table
+):
     row_matches = sc.compare_tables(engine, table_lhs, table_rhs).row_matches
     assert row_matches.n_joined_equal == 2
     assert row_matches.n_joined_unequal == 0

--- a/tests/analysis/table_comparison/test_report.py
+++ b/tests/analysis/table_comparison/test_report.py
@@ -5,7 +5,6 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
@@ -17,7 +16,7 @@ def expected_description() -> str:
 
 
 def test_report_simple(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
     expected_description: str,

--- a/tests/analysis/table_comparison/test_report.py
+++ b/tests/analysis/table_comparison/test_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify the report generation of a table comparison."""

--- a/tests/analysis/table_comparison/test_row_counts.py
+++ b/tests/analysis/table_comparison/test_row_counts.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify basic behavior for determining row counts."""

--- a/tests/analysis/table_comparison/test_row_counts.py
+++ b/tests/analysis/table_comparison/test_row_counts.py
@@ -5,38 +5,37 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
-def test_row_counts_equal_counts(engine: Engine, table_students: sa.Table):
+def test_row_counts_equal_counts(engine: sa.Engine, table_students: sa.Table):
     # Check row counts same in identical tables
     row_counts = sc.compare_tables(engine, table_students, table_students).row_counts
     assert row_counts.left == 5
     assert row_counts.right == 5
 
 
-def test_row_counts_equal_equal(engine: Engine, table_students: sa.Table):
+def test_row_counts_equal_equal(engine: sa.Engine, table_students: sa.Table):
     # Check row counts equal in identical tables
     row_counts = sc.compare_tables(engine, table_students, table_students).row_counts
     assert row_counts.equal
 
 
-def test_row_counts_equal_diff(engine: Engine, table_students: sa.Table):
+def test_row_counts_equal_diff(engine: sa.Engine, table_students: sa.Table):
     # Check row counts are not different in identical tables
     row_counts = sc.compare_tables(engine, table_students, table_students).row_counts
     assert not row_counts.diff
 
 
-def test_row_counts_equal_prop(engine: Engine, table_students: sa.Table):
+def test_row_counts_equal_prop(engine: sa.Engine, table_students: sa.Table):
     # Check row count proportion is 1 in identical tables
     row_counts = sc.compare_tables(engine, table_students, table_students).row_counts
     assert row_counts.fraction_left == pytest.approx(1)
 
 
 def test_row_counts_unequal_counts(
-    engine: Engine,
+    engine: sa.Engine,
     table_students: sa.Table,
     table_students_small: sa.Table,
 ):

--- a/tests/analysis/table_comparison/test_row_matches.py
+++ b/tests/analysis/table_comparison/test_row_matches.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify basic behavior for determining row matches."""

--- a/tests/analysis/table_comparison/test_row_matches.py
+++ b/tests/analysis/table_comparison/test_row_matches.py
@@ -5,23 +5,22 @@
 
 import pandas as pd
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
-def test_row_matches_same_n_matched(engine: Engine, table_students: sa.Table):
+def test_row_matches_same_n_matched(engine: sa.Engine, table_students: sa.Table):
     row_matches = sc.compare_tables(engine, table_students, table_students).row_matches
     assert row_matches.n_joined_equal == 5
     assert row_matches.n_joined_unequal == 0
 
 
-def test_row_matches_same_n_unjoined(engine: Engine, table_students: sa.Table):
+def test_row_matches_same_n_unjoined(engine: sa.Engine, table_students: sa.Table):
     row_matches = sc.compare_tables(engine, table_students, table_students).row_matches
     assert row_matches.n_unjoined_left == row_matches.n_unjoined_right == 0
 
 
-def test_row_matches_same_unjoined(engine: Engine, table_students: sa.Table):
+def test_row_matches_same_unjoined(engine: sa.Engine, table_students: sa.Table):
     comp = sc.compare_tables(engine, table_students, table_students)
     with engine.connect() as conn:
         left_res = conn.execute(comp.row_matches.unjoined_left).all()
@@ -29,7 +28,7 @@ def test_row_matches_same_unjoined(engine: Engine, table_students: sa.Table):
     assert left_res == right_res == []
 
 
-def test_row_matches_same_joined(engine: Engine, table_students: sa.Table):
+def test_row_matches_same_joined(engine: sa.Engine, table_students: sa.Table):
     comp = sc.compare_tables(engine, table_students, table_students)
     with engine.connect() as conn:
         joined_unequal_res = conn.execute(comp.row_matches.joined_unequal).all()
@@ -40,7 +39,7 @@ def test_row_matches_same_joined(engine: Engine, table_students: sa.Table):
 
 
 def test_row_matches_n_different_unjoined(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -51,7 +50,7 @@ def test_row_matches_n_different_unjoined(
 
 
 def test_row_matches_n_different_joined(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -63,7 +62,7 @@ def test_row_matches_n_different_joined(
 
 
 def test_row_matches_different_unjoined(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -77,7 +76,7 @@ def test_row_matches_different_unjoined(
 
 
 def test_row_matches_different_joined(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):
@@ -94,7 +93,7 @@ def test_row_matches_different_joined(
 
 
 def test_row_matches_unjoined_columns(
-    engine: Engine, table_students: sa.Table, table_students_small: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_small: sa.Table
 ):
     # Check that selects on unjoined rows only contain columns of corresponding table
     row_matches = sc.compare_tables(
@@ -110,7 +109,7 @@ def test_row_matches_unjoined_columns(
 
 
 def test_row_matches_unjoined_columns_mapped(
-    engine: Engine, table_students: sa.Table, table_students_renamed: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_renamed: sa.Table
 ):
     # Check that selects on unjoined rows only contain columns of corresponding table even if
     # column names are mapped
@@ -129,7 +128,7 @@ def test_row_matches_unjoined_columns_mapped(
     assert set(unjoined_right.columns) == {"id_v2", "name_v2", "age_v2", "gpa_v2"}
 
 
-def test_row_matches_column_names(engine: Engine, table_students: sa.Table):
+def test_row_matches_column_names(engine: sa.Engine, table_students: sa.Table):
     row_matches = sc.compare_tables(engine, table_students, table_students).row_matches
     equal = pd.read_sql(row_matches.joined_equal, con=engine)
 
@@ -146,7 +145,7 @@ def test_row_matches_column_names(engine: Engine, table_students: sa.Table):
 
 
 def test_row_matches_float_precision(
-    engine: Engine, table_students: sa.Table, table_students_modified_3: sa.Table
+    engine: sa.Engine, table_students: sa.Table, table_students_modified_3: sa.Table
 ):
     row_matches_1 = sc.compare_tables(
         engine, table_students, table_students_modified_3

--- a/tests/analysis/table_comparison/test_string_collation.py
+++ b/tests/analysis/table_comparison/test_string_collation.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify SQLCompyre's behavior for comparing string

--- a/tests/analysis/table_comparison/test_string_collation.py
+++ b/tests/analysis/table_comparison/test_string_collation.py
@@ -8,8 +8,6 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 from tests._shared import TableFactory
@@ -19,23 +17,23 @@ from tests._shared import TableFactory
 # -------------------------------------------------------------------------------------------------
 
 
-def table_columns(engine: Engine) -> list[Column]:
+def table_columns(engine: sa.Engine) -> list[sa.Column]:
     return [
-        Column("id", Integer(), primary_key=True),
-        Column(
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
             "value",
-            String(collation=engine.dialect.case_insensitive_collation),  # type: ignore
+            sa.String(collation=engine.dialect.case_insensitive_collation),  # type: ignore
         ),
-        Column(
+        sa.Column(
             "value_case_sensitive",
-            String(collation=engine.dialect.case_sensitive_collation),  # type: ignore
+            sa.String(collation=engine.dialect.case_sensitive_collation),  # type: ignore
         ),
-        Column("non_str_value", Integer()),
+        sa.Column("non_str_value", sa.Integer()),
     ]
 
 
 @pytest.fixture(scope="module")
-def table_lhs(table_factory: TableFactory, engine: Engine) -> sa.Table:
+def table_lhs(table_factory: TableFactory, engine: sa.Engine) -> sa.Table:
     data: list[dict[str, Any]] = [
         dict(id=1, value="test", value_case_sensitive="test", non_str_value=1),
         dict(id=2, value="Test", value_case_sensitive="Test", non_str_value=1),
@@ -44,7 +42,7 @@ def table_lhs(table_factory: TableFactory, engine: Engine) -> sa.Table:
 
 
 @pytest.fixture(scope="module")
-def table_rhs(table_factory: TableFactory, engine: Engine) -> sa.Table:
+def table_rhs(table_factory: TableFactory, engine: sa.Engine) -> sa.Table:
     data: list[dict[str, Any]] = [
         dict(id=1, value="test", value_case_sensitive="test", non_str_value=1),
         dict(id=2, value="TEST", value_case_sensitive="TEST", non_str_value=1),
@@ -58,7 +56,7 @@ def table_rhs(table_factory: TableFactory, engine: Engine) -> sa.Table:
 
 
 def test_str_equal_no_collation(
-    engine: Engine, table_lhs: sa.Table, table_rhs: sa.Table
+    engine: sa.Engine, table_lhs: sa.Table, table_rhs: sa.Table
 ):
     column_matches = sc.compare_tables(engine, table_lhs, table_rhs).column_matches
     assert column_matches.fraction_same["value"] == 1
@@ -67,7 +65,7 @@ def test_str_equal_no_collation(
 
 
 def test_str_equal_case_sensitive_collation(
-    engine: Engine,
+    engine: sa.Engine,
     table_lhs: sa.Table,
     table_rhs: sa.Table,
 ):

--- a/tests/analysis/table_comparison/test_top_changes.py
+++ b/tests/analysis/table_comparison/test_top_changes.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """This file contains tests that verify the "top changes" comparison."""

--- a/tests/analysis/table_comparison/test_top_changes.py
+++ b/tests/analysis/table_comparison/test_top_changes.py
@@ -4,19 +4,18 @@
 """This file contains tests that verify the "top changes" comparison."""
 
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine
 
 import sqlcompyre as sc
 
 
-def test_by_top_changes_same(engine: Engine, table_students: sa.Table):
+def test_by_top_changes_same(engine: sa.Engine, table_students: sa.Table):
     comp = sc.compare_tables(engine, table_students, table_students)
     assert not comp.get_top_changes("age")
     assert not comp.get_top_changes("name")
 
 
 def test_column_matches_changes_different(
-    engine: Engine,
+    engine: sa.Engine,
     table_students_modified_1: sa.Table,
     table_students_modified_2: sa.Table,
 ):

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -3,22 +3,23 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy import Integer
-from sqlalchemy.engine import Engine
 
 from tests._shared import SchemaFactory, TableFactory
 
 
 def table_columns() -> list[sa.Column]:
-    return [sa.Column("id", Integer(), primary_key=True), sa.Column("value", Integer())]
+    return [
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("value", sa.Integer()),
+    ]
 
 
 def table_columns_alt() -> list[sa.Column]:
-    return [sa.Column("new_id", Integer(), primary_key=True)]
+    return [sa.Column("new_id", sa.Integer(), primary_key=True)]
 
 
 @pytest.fixture(scope="session")
-def schema_1(engine: Engine, schema_factory: SchemaFactory) -> str:
+def schema_1(engine: sa.Engine, schema_factory: SchemaFactory) -> str:
     schema = schema_factory.create("compyre_cli_1")
     factory = TableFactory(engine, schema)
     factory.create("table1", table_columns(), [dict(id=1, value=5)])
@@ -28,7 +29,7 @@ def schema_1(engine: Engine, schema_factory: SchemaFactory) -> str:
 
 
 @pytest.fixture(scope="session")
-def schema_2(engine: Engine, schema_factory: SchemaFactory) -> str:
+def schema_2(engine: sa.Engine, schema_factory: SchemaFactory) -> str:
     schema = schema_factory.create("compyre_cli_2")
     factory = TableFactory(engine, schema)
     factory.create("table1", table_columns(), [dict(id=1, value=4)])

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,7 +1,6 @@
 # Copyright (c) QuantCo 2024-2024
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 from pathlib import Path
 
 import pytest

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import os
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.engine import Engine, url
 
 from tests._shared import SchemaFactory, TableFactory, dialect_from_env
 
@@ -26,17 +25,17 @@ def skip_for_dialect(request, engine):
 
 
 @pytest.fixture(scope="session")
-def connection_string() -> url.URL:
-    return url.make_url(os.environ["DB_CONNECTION_STRING"])
+def connection_string() -> sa.URL:
+    return sa.make_url(os.environ["DB_CONNECTION_STRING"])
 
 
 @pytest.fixture(scope="session")
-def connection_string_raw_string(connection_string: url.URL) -> str:
+def connection_string_raw_string(connection_string: sa.URL) -> str:
     return connection_string.render_as_string(hide_password=False)
 
 
 @pytest.fixture(scope="session")
-def engine(connection_string: url.URL) -> Engine:
+def engine(connection_string: sa.URL) -> sa.Engine:
     return sa.create_engine(connection_string)
 
 
@@ -46,7 +45,7 @@ def engine(connection_string: url.URL) -> Engine:
 
 
 @pytest.fixture(scope="session")
-def schema_factory(connection_string: url.URL) -> SchemaFactory:
+def schema_factory(connection_string: sa.URL) -> SchemaFactory:
     return SchemaFactory(connection_string)
 
 
@@ -56,7 +55,7 @@ def schema_factory(connection_string: url.URL) -> SchemaFactory:
 
 
 @pytest.fixture(scope="session")
-def table_factory(engine: Engine, schema_factory: SchemaFactory) -> TableFactory:
+def table_factory(engine: sa.Engine, schema_factory: SchemaFactory) -> TableFactory:
     if not engine.dialect.supports_schemas:  # type: ignore
         return TableFactory(engine, None)
     schema = schema_factory.create("compyre_test")
@@ -68,6 +67,8 @@ def table_factory(engine: Engine, schema_factory: SchemaFactory) -> TableFactory
     reason="Database system does not support schemas.",
 )
 @pytest.fixture(scope="session")
-def table_factory_extra(engine: Engine, schema_factory: SchemaFactory) -> TableFactory:
+def table_factory_extra(
+    engine: sa.Engine, schema_factory: SchemaFactory
+) -> TableFactory:
     schema = schema_factory.create("compyre_test_extra")
     return TableFactory(engine, schema)


### PR DESCRIPTION
# Motivation

Although this package already requires SQLAlchemy v2, its type annotations are still needlessly complex as this was required for SQLAlchemy v1.4.
