### PR TITLE
test: Add tests for DuckDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,14 @@ jobs:
       fail-fast: false
       matrix:
         environment: [py311, py312, py313]
-        database: [sqlite, mssql]
+        database: [sqlite, mssql, duckdb]
+        include:
+          - database: sqlite
+            connection-string: sqlite:///test.sqlite3
+          - database: mssql
+            connection-string: mssql+pyodbc://sa:Passw0rd@localhost:1433/master?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=no
+          - database: duckdb
+            connection-string: duckdb:///test.duckdb
     steps:
       - name: Checkout branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -55,14 +62,10 @@ jobs:
         uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
         with:
           environments: ${{ matrix.environment }}
+          activate-environment: true
       - name: Install repository
-        run: pixi run -e ${{ matrix.environment }} postinstall
-      - name: Set DB connection string
-        run: |
-          if [ "${{ matrix.database }}" == "sqlite" ]; then
-            echo "DB_CONNECTION_STRING=sqlite:///test.sqlite3" >> $GITHUB_ENV
-          else
-            echo "DB_CONNECTION_STRING=mssql+pyodbc://sa:Passw0rd@localhost:1433/master?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=no" >> $GITHUB_ENV
-          fi
+        run: pixi run postinstall
       - name: Run pytest
-        run: pixi run -e ${{ matrix.environment }} test-coverage --color=yes
+        run: pixi run test-coverage --color=yes
+        env:
+          DB_CONNECTION_STRING: ${{ matrix.connection-string }}

--- a/sqlcompyre/analysis/dialects/__init__.py
+++ b/sqlcompyre/analysis/dialects/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2024-2024
+# Copyright (c) QuantCo 2024-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from sqlalchemy.dialects import registry

--- a/sqlcompyre/analysis/dialects/__init__.py
+++ b/sqlcompyre/analysis/dialects/__init__.py
@@ -37,3 +37,18 @@ try:
     )
 except ImportError:
     pass
+
+# -------------------------------------------------------------------------------------------------
+# DuckDB
+# -------------------------------------------------------------------------------------------------
+
+try:
+    from .duckdb import DuckDBDialect  # noqa
+
+    registry.register(
+        "duckdb",
+        "sqlcompyre.analysis.dialects",
+        "DuckDBDialect",
+    )
+except ImportError:
+    pass

--- a/sqlcompyre/analysis/dialects/duckdb.py
+++ b/sqlcompyre/analysis/dialects/duckdb.py
@@ -1,0 +1,16 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+from duckdb_engine import Dialect as SqlAlchemyDuckdbDialect
+
+from ._base import DialectProtocol
+
+
+class DuckDBDialect(SqlAlchemyDuckdbDialect, DialectProtocol):  # type: ignore
+    name: str = "duckdb"
+    verbose_name: str = "DuckDB"
+    supports_schemas: bool = False
+    supports_multi_part_schemas: bool = False
+    case_sensitive_collation: str = "BINARY"
+    case_insensitive_collation: str = "NOCASE"
+    views_support_notnull_columns: bool = False

--- a/tests/_shared/dialects.py
+++ b/tests/_shared/dialects.py
@@ -33,5 +33,9 @@ def dialect_from_connection_url(conn_url: sa.URL) -> DialectProtocol:
             from sqlcompyre.analysis.dialects import SQLiteDialect
 
             return SQLiteDialect()
+        case "duckdb":
+            from sqlcompyre.analysis.dialects import DuckDBDialect
+
+            return DuckDBDialect()
         case _:
             raise NotImplementedError

--- a/tests/_shared/dialects.py
+++ b/tests/_shared/dialects.py
@@ -36,6 +36,6 @@ def dialect_from_connection_url(conn_url: sa.URL) -> DialectProtocol:
         case "duckdb":
             from sqlcompyre.analysis.dialects import DuckDBDialect
 
-            return DuckDBDialect()
+            return DuckDBDialect()  # type: ignore
         case _:
             raise NotImplementedError

--- a/tests/analysis/dialects/test_mssql.py
+++ b/tests/analysis/dialects/test_mssql.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def table_columns() -> list[sa.Column]:
-    return [sa.Column("id", sa.Integer(), primary_key=True)]
+    return [sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False)]
 
 
 @pytest.fixture(scope="session")

--- a/tests/analysis/schema_comparison/conftest.py
+++ b/tests/analysis/schema_comparison/conftest.py
@@ -11,7 +11,7 @@ from tests._shared import SchemaFactory, TableFactory
 
 def table_columns() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("value", sa.Integer()),
     ]
 

--- a/tests/analysis/table_comparison/conftest.py
+++ b/tests/analysis/table_comparison/conftest.py
@@ -19,7 +19,7 @@ STUDENT_DATA = [
 
 def base_columns() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("name", sa.String(length=50)),
         sa.Column("age", sa.Integer()),
         sa.Column("gpa", sa.Float()),
@@ -28,7 +28,7 @@ def base_columns() -> list[sa.Column]:
 
 def alt_columns() -> list[sa.Column]:
     return [
-        sa.Column("id_v2", sa.Integer(), primary_key=True),
+        sa.Column("id_v2", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("name_v2", sa.String(length=50)),
         sa.Column("age_v2", sa.Integer()),
         sa.Column("gpa_v2", sa.Float()),
@@ -37,7 +37,7 @@ def alt_columns() -> list[sa.Column]:
 
 def alt_columns_small() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("name", sa.String(length=50)),
         sa.Column("age_v2", sa.Integer()),
         sa.Column("gpa_v2", sa.Float()),
@@ -46,7 +46,7 @@ def alt_columns_small() -> list[sa.Column]:
 
 def cased_columns() -> list[sa.Column]:
     return [
-        sa.Column("Id", sa.Integer(), primary_key=True),
+        sa.Column("Id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("Name", sa.String(length=50)),
         sa.Column("Age", sa.Integer()),
         sa.Column("Gpa", sa.Float()),

--- a/tests/analysis/table_comparison/test_by_column.py
+++ b/tests/analysis/table_comparison/test_by_column.py
@@ -20,7 +20,7 @@ from tests._shared import TableFactory
 
 def table_columns() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("value", sa.Integer(), nullable=True),
         sa.Column("value_1", sa.Integer(), nullable=True),
     ]

--- a/tests/analysis/table_comparison/test_null_values.py
+++ b/tests/analysis/table_comparison/test_null_values.py
@@ -19,7 +19,7 @@ from tests._shared import TableFactory
 
 def table_columns() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("value", sa.Integer(), nullable=True),
     ]
 

--- a/tests/analysis/table_comparison/test_only_primary_key.py
+++ b/tests/analysis/table_comparison/test_only_primary_key.py
@@ -18,7 +18,7 @@ from tests._shared import TableFactory
 
 
 def table_columns() -> list[sa.Column]:
-    return [sa.Column("id", sa.Integer(), primary_key=True)]
+    return [sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False)]
 
 
 @pytest.fixture(scope="module")

--- a/tests/analysis/table_comparison/test_string_collation.py
+++ b/tests/analysis/table_comparison/test_string_collation.py
@@ -19,7 +19,7 @@ from tests._shared import TableFactory
 
 def table_columns(engine: sa.Engine) -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column(
             "value",
             sa.String(collation=engine.dialect.case_insensitive_collation),  # type: ignore

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -9,13 +9,13 @@ from tests._shared import SchemaFactory, TableFactory
 
 def table_columns() -> list[sa.Column]:
     return [
-        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False),
         sa.Column("value", sa.Integer()),
     ]
 
 
 def table_columns_alt() -> list[sa.Column]:
-    return [sa.Column("new_id", sa.Integer(), primary_key=True)]
+    return [sa.Column("new_id", sa.Integer(), primary_key=True, autoincrement=False)]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Motivation

DuckDB can be used easily to run SQLCompyre on parquet files.
